### PR TITLE
Don’t put Sarah on a line by herself

### DIFF
--- a/app/components/Admins/styles.scss
+++ b/app/components/Admins/styles.scss
@@ -22,7 +22,7 @@
   & h2 { font-size: 30px; }
 }
 .admin {
-  width: calc(100%/3);
+  width: 25%;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;


### PR DESCRIPTION
Your use of 33% width image divs with four admins puts Sarah below the
other admins on a line by herself. This was probably unintentional, but
it sends a message that we hold men in higher regard. We don’t.

When more admins are added to the page, 33% styling may be appropriate,
but consider alphabetizing the admins by last name so we wouldn’t have,
say, Sarah and Julie on line 2, and all the men on line 1.

Thanks!

Before:

![before](https://user-images.githubusercontent.com/2135631/30969659-10fe5b68-a431-11e7-8064-17d512f02cb3.png)

After:

![after](https://user-images.githubusercontent.com/2135631/30969665-151d2508-a431-11e7-9cc0-8142e4f849b5.png)
