### PR TITLE
Yarn version greater than or equal to version 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepush": "yarn test && yarn prod:build"
   },
   "engines": {
-    "yarn": "1.0.2"
+    "yarn": ">= 1.0.2"
   },
   "browserslist": [
     "> 1%"


### PR DESCRIPTION
The previous package.json file had strictly defined yarn version 1.0.2. I have updated the file to accept at minimum yarn version 1.0.2 while working with any new versions as well.