### PR TITLE
fix: overlapping resource icons

### DIFF
--- a/app/components/Resources/styles.scss
+++ b/app/components/Resources/styles.scss
@@ -27,6 +27,7 @@
 }
 .item {
   width: 25%;
+  min-width: 200px;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -35,10 +36,8 @@
 .logo {
   width: 100%;
   text-align: center;
-  flex: auto;
 }
 .image {
-  flex: auto;
   width: 100%;
   height: auto;
   max-width: 265px;


### PR DESCRIPTION
First PR. Let me know if I should be PR'ing against a different branch (ie. `dev`, or `staging`)

Addresses: Bug https://github.com/FCCColumbus/F3C_Website/issues/30
- Set a min-width on our flex item to force a row wrap before they overlap
- Website is now responsive to about `325px` or so before other unrelated issues crop up

I don't shrink the icons, as suggested, but I do prevent the overlap 🤷‍♂️ 