### PR TITLE
Patch: graphql-server-proxy-config

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -10,7 +10,7 @@ import 'font-awesome/css/font-awesome.min.css'
 import 'sharedStyles/theme.scss'
 
 const client = new ApolloClient({
-  uri: 'https://graphql.fcccolumbus.com/graphql',
+  uri: '/api/graphql',
 })
 
 ReactDOM.render(<ApolloProvider client={client}>{getRoutes()}</ApolloProvider>, document.getElementById('app'))

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
-/*    /index.html   200
+/api/* https://graphql.fcccolumbus.com/:splat    200! # API Proxy
+/*    /index.html 200 # SPA redirect

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -167,7 +167,7 @@ const developmentConfig = {
     },
     proxy: {
       '/api': {
-        target: '',
+        target: 'https://graphql.fcccolumbus.com/',
         secure: false,
         changeOrigin: true,
         pathRewrite: { '/api': '' },


### PR DESCRIPTION
Proxy patch so the client can navigate from the need of the CORS dependency serverside.

Both Production and local dev are configured to proxy the GraphQL server without any interruption to existing logic.